### PR TITLE
Fix typo in varname snippet

### DIFF
--- a/docbook.code-snippets
+++ b/docbook.code-snippets
@@ -299,7 +299,7 @@
 		"scope": "xml",
 		"prefix": "va",
 		"body": [
-			"<varnamr>${1:insert variable}</varname>"
+			"<varname>${1:insert variable}</varname>"
 		]
 	},
 	"X-reference": {


### PR DESCRIPTION
Just a minor typo in your snippet. :wink: 