### PR TITLE
Update cspell config snippet

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -27,11 +27,11 @@
     ],
     // spellcheck settings
     "cSpell.enabled": true,
-    "cSpell.enabledLanguageIds": [
-        "xml",
-        "asciidoc",
-        "markdown"
-    ],
+    "cSpell.enabledFileTypes": {
+        "asciidoc": true,
+        "markdown": true,
+        "xml": true,
+    },
     "cSpell.caseSensitive": true,
     "cSpell.minWordLength": 3,
     "cSpell.customDictionaries": {


### PR DESCRIPTION
As we just learned in your training today, the option is now called 'enabledFileTypes'